### PR TITLE
[RFR] Schema reference

### DIFF
--- a/packages/aor-graphql-client/README.md
+++ b/packages/aor-graphql-client/README.md
@@ -40,7 +40,7 @@ yarn add aor-graphql-client
 
 ## Usage
 
-```js
+```jsx
 // in App.js
 import React, { Component } from 'react';
 import buildApolloClient from 'aor-graphql-client';
@@ -106,6 +106,25 @@ You can also supply your own [ApolloClient](http://dev.apollodata.com/core/apoll
 buildApolloClient({ client: myClient });
 ```
 
+### IntrospectionOptions
+
+Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly.
+
+```jsx
+import { __schema as schema } from './schema';
+
+const introspectionOptions = {
+  schema
+};
+
+buildApolloClient({
+    introspection: introspectionOptions
+});
+```
+
+The `./schema` file is a `schema.json` in `./scr` retrieved with [`get-graphql-schema --json <graphql_endpoint>`](https://github.com/graphcool/get-graphql-schema).
+
+
 ## Specify your queries and mutations
 
 For the client to know how to map Admin-on-rest request to apollo queries and mutations, you must provide a `queryBuilder` option. The `queryBuilder` is a factory function which will be called with the introspection query result.
@@ -125,8 +144,8 @@ For example:
             name: 'Post',
             kind: 'OBJECT',
             fields: [
-                { name: 'id', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'ID } } },
-                { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String } } },
+                { name: 'id', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'ID' } } },
+                { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String' } } },
                 ...
             ]
         },
@@ -136,7 +155,7 @@ For example:
         {
             name: 'createPost',
             args: [
-                { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String } } }
+                { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String' } } }
             ],
             type : { kind: 'OBJECT', name: 'Category' }
         },
@@ -148,15 +167,15 @@ For example:
                 name: 'Post',
                 kind: 'OBJECT',
                 fields: [
-                    { name: 'id', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'ID } } },
-                    { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String } } },
+                    { name: 'id', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'ID' } } },
+                    { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String' } } },
                     ...
                 ]
             },
             GET_LIST: {
                 name: 'createPost',
                 args: [
-                    { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String } } }
+                    { name: 'title', type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String' } } }
                 ],
                 type : { kind: 'OBJECT', name: 'Category' }
             },

--- a/packages/aor-graphql-client/README.md
+++ b/packages/aor-graphql-client/README.md
@@ -108,7 +108,7 @@ buildApolloClient({ client: myClient });
 
 ### IntrospectionOptions
 
-Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly. This speeds up the initial rendering of the `Admin` component.
+Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly. This speeds up the initial rendering of the `Admin` component as it no longer has to wait for the introspection query request to resolve.
 
 ```jsx
 import { __schema as schema } from './schema';

--- a/packages/aor-graphql-client/README.md
+++ b/packages/aor-graphql-client/README.md
@@ -108,7 +108,7 @@ buildApolloClient({ client: myClient });
 
 ### IntrospectionOptions
 
-Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly.
+Instead of running an IntrospectionQuery you can also provide the IntrospectionQuery result directly. This speeds up the initial rendering of the `Admin` component.
 
 ```jsx
 import { __schema as schema } from './schema';
@@ -124,6 +124,7 @@ buildApolloClient({
 
 The `./schema` file is a `schema.json` in `./scr` retrieved with [`get-graphql-schema --json <graphql_endpoint>`](https://github.com/graphcool/get-graphql-schema).
 
+> Note: Importing the `schema.json` file will significantly increase the bundle size.
 
 ## Specify your queries and mutations
 

--- a/packages/aor-graphql-client/src/introspection.js
+++ b/packages/aor-graphql-client/src/introspection.js
@@ -4,27 +4,27 @@ import gql from 'graphql-tag';
 import { GET_LIST, GET_ONE, ALL_TYPES } from './constants';
 
 export const filterTypesByIncludeExclude = ({ include, exclude }) => {
-  if (include) {
-    if (Array.isArray(include)) {
-      return type => include.includes(type.name);
+    if (include) {
+        if (Array.isArray(include)) {
+            return type => include.includes(type.name);
+        }
+
+        if (typeof include === 'function') {
+            return type => include(type);
+        }
     }
 
-    if (typeof include === 'function') {
-      return type => include(type);
-    }
-  }
+    if (exclude) {
+        if (Array.isArray(exclude)) {
+            return type => !exclude.includes(type.name);
+        }
 
-  if (exclude) {
-    if (Array.isArray(exclude)) {
-      return type => !exclude.includes(type.name);
+        if (typeof exclude === 'function') {
+            return type => !exclude(type);
+        }
     }
 
-    if (typeof exclude === 'function') {
-      return type => !exclude(type);
-    }
-  }
-
-  return () => true;
+    return () => true;
 };
 
 /**
@@ -32,48 +32,38 @@ export const filterTypesByIncludeExclude = ({ include, exclude }) => {
  * @param {Object} options The introspection options
  */
 export default async (client, options) => {
-  const schema = options.schema
-    ? options.schema
-    : await client
-        .query({ query: gql`${introspectionQuery}` })
-        .then(({ data: { __schema } }) => __schema);
+    const schema = options.schema
+        ? options.schema
+        : await client.query({ query: gql`${introspectionQuery}` }).then(({ data: { __schema } }) => __schema);
 
-  const queries = schema.types.reduce((acc, type) => {
-    if (type.name !== 'Query' && type.name !== 'Mutation') return acc;
+    const queries = schema.types.reduce((acc, type) => {
+        if (type.name !== 'Query' && type.name !== 'Mutation') return acc;
 
-    return [...acc, ...type.fields];
-  }, []);
+        return [...acc, ...type.fields];
+    }, []);
 
-  const types = schema.types.filter(
-    type => type.name !== 'Query' && type.name !== 'Mutation'
-  );
+    const types = schema.types.filter(type => type.name !== 'Query' && type.name !== 'Mutation');
 
-  const isResource = type =>
-    queries.some(
-      query => query.name === options.operationNames[GET_LIST](type)
-    ) &&
-    queries.some(query => query.name === options.operationNames[GET_ONE](type));
+    const isResource = type =>
+        queries.some(query => query.name === options.operationNames[GET_LIST](type)) &&
+        queries.some(query => query.name === options.operationNames[GET_ONE](type));
 
-  const buildResource = type =>
-    ALL_TYPES.reduce(
-      (acc, aorFetchType) => ({
-        ...acc,
-        [aorFetchType]: queries.find(
-          query => query.name == options.operationNames[aorFetchType](type)
-        ),
-      }),
-      { type }
-    );
+    const buildResource = type =>
+        ALL_TYPES.reduce(
+            (acc, aorFetchType) => ({
+                ...acc,
+                [aorFetchType]: queries.find(query => query.name == options.operationNames[aorFetchType](type)),
+            }),
+            { type },
+        );
 
-  const potentialResources = types.filter(isResource);
-  const filteredResources = potentialResources.filter(
-    filterTypesByIncludeExclude(options)
-  );
-  const resources = filteredResources.map(buildResource);
+    const potentialResources = types.filter(isResource);
+    const filteredResources = potentialResources.filter(filterTypesByIncludeExclude(options));
+    const resources = filteredResources.map(buildResource);
 
-  return {
-    types,
-    queries,
-    resources,
-  };
+    return {
+        types,
+        queries,
+        resources,
+    };
 };


### PR DESCRIPTION
See #20.

This is just a rough first pass at implementing it.

Improvements could be using a different format, [`.graphql`](https://www.graph.cool/docs/faq/graphql-sdl-schema-definition-language-kr84dktnp0/) instead of `.json`.

I am using it like this:
```jsx
import { __schema as schema } from './schema';
const introspectionOptions = {
  schema,
};
export default () =>
  buildApolloClient({
    client,
    introspection: introspectionOptions,
  });
```

The `./schema` file is a `schema.json` in `./scr` retrieved with [`get-graphql-schema --json <graphql_endpoint>`](https://github.com/graphcool/get-graphql-schema).
