### PR TITLE
Missing resource name in error message

### DIFF
--- a/packages/aor-graphql-client-graphcool/src/buildQuery.js
+++ b/packages/aor-graphql-client-graphcool/src/buildQuery.js
@@ -15,7 +15,7 @@ export const buildQueryFactory = (
 
         if (!resource) {
             throw new Error(
-                `Unknown resource ${resource}. Make sure it has been declared on your server side schema. Known resources are ${knownResources.join(', ')}`,
+                `Unknown resource ${resourceName}. Make sure it has been declared on your server side schema. Known resources are ${knownResources.join(', ')}`,
             );
         }
 


### PR DESCRIPTION
Unknown resource *undefined*. Make sure it has been declared on your server side schema. Known resources are...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marmelab/aor-graphql/43)
<!-- Reviewable:end -->
