### PR TITLE
(bugfix) Remove 1 to 1 relation & [Enum!]! type fix

### DIFF
--- a/packages/aor-graphql-client-graphcool/src/buildGqlQuery.test.js
+++ b/packages/aor-graphql-client-graphcool/src/buildGqlQuery.test.js
@@ -37,18 +37,21 @@ describe('buildApolloArgs', () => {
                         },
                         {
                             name: 'barId',
-                            type: { kind: TypeKind.SCALAR },
+                            type: { kind: TypeKind.SCALAR, name: 'ID' },
                         },
                         {
                             name: 'barIds',
-                            type: { kind: TypeKind.SCALAR },
+                            type: {
+                                kind: TypeKind.LIST,
+                                ofType: { kind: TypeKind.NON_NULL, ofType: { kind: TypeKind.SCALAR, name: 'ID' } },
+                            },
                         },
                         { name: 'bar' },
                     ],
                 },
                 { foo: 'foo_value', barId: 100, barIds: [101, 102] },
             ),
-        ).toEqual({ $foo: 'Int!', $barId: 'ID!', $barIds: '[ID!]!' });
+        ).toEqual({ $foo: 'Int!', $barId: 'ID', $barIds: '[ID!]!' });
     });
 });
 

--- a/packages/aor-graphql-client-graphcool/src/isList.js
+++ b/packages/aor-graphql-client-graphcool/src/isList.js
@@ -1,0 +1,11 @@
+import { TypeKind } from 'graphql';
+
+const isList = type => {
+    if (type.kind === TypeKind.NON_NULL) {
+        return isList(type.ofType);
+    }
+
+    return type.kind === TypeKind.LIST;
+};
+
+export default isList;

--- a/packages/aor-graphql-client-graphcool/src/isList.test.js
+++ b/packages/aor-graphql-client-graphcool/src/isList.test.js
@@ -1,0 +1,22 @@
+import { TypeKind } from 'graphql';
+import isList from './isList';
+
+describe('isList', () => {
+    it('returns the correct type for SCALAR types', () => {
+        expect(isList({ name: 'foo', kind: TypeKind.SCALAR })).toEqual(false);
+    });
+    it('returns the correct type for NON_NULL types', () => {
+        expect(isList({ kind: TypeKind.NON_NULL, ofType: { name: 'foo', kind: TypeKind.SCALAR } })).toEqual(false);
+    });
+    it('returns the correct type for LIST types', () => {
+        expect(isList({ kind: TypeKind.LIST, ofType: { name: 'foo', kind: TypeKind.SCALAR } })).toEqual(true);
+    });
+    it('returns the correct type for NON_NULL LIST types', () => {
+        expect(
+            isList({
+                kind: TypeKind.NON_NULL,
+                ofType: { kind: TypeKind.LIST, ofType: { name: 'foo', kind: TypeKind.SCALAR } },
+            }),
+        ).toEqual(true);
+    });
+});

--- a/packages/aor-graphql-client-graphcool/src/isRequired.js
+++ b/packages/aor-graphql-client-graphcool/src/isRequired.js
@@ -1,0 +1,11 @@
+import { TypeKind } from 'graphql';
+
+const isRequired = type => {
+    if (type.kind === TypeKind.LIST) {
+        return isRequired(type.ofType);
+    }
+
+    return type.kind === TypeKind.NON_NULL;
+};
+
+export default isRequired;

--- a/packages/aor-graphql-client-graphcool/src/isRequired.test.js
+++ b/packages/aor-graphql-client-graphcool/src/isRequired.test.js
@@ -1,0 +1,22 @@
+import { TypeKind } from 'graphql';
+import isRequired from './isRequired';
+
+describe('isRequired', () => {
+    it('returns the correct type for SCALAR types', () => {
+        expect(isRequired({ name: 'foo', kind: TypeKind.SCALAR })).toEqual(false);
+    });
+    it('returns the correct type for NON_NULL types', () => {
+        expect(isRequired({ kind: TypeKind.NON_NULL, ofType: { name: 'foo', kind: TypeKind.SCALAR } })).toEqual(true);
+    });
+    it('returns the correct type for LIST types', () => {
+        expect(isRequired({ kind: TypeKind.LIST, ofType: { name: 'foo', kind: TypeKind.SCALAR } })).toEqual(false);
+    });
+    it('returns the correct type for NON_NULL LIST types', () => {
+        expect(
+            isRequired({
+                kind: TypeKind.NON_NULL,
+                ofType: { kind: TypeKind.LIST, ofType: { name: 'foo', kind: TypeKind.SCALAR } },
+            }),
+        ).toEqual(true);
+    });
+});


### PR DESCRIPTION
These are the changes I needed in a project to fix the removal of a 1 to 1 relation & update a type that had a [Enum!]! field.

Probably should move the util functions into a folder but I was using the same style as getFinalType.