### PR TITLE
apollo-client 2.0

### DIFF
--- a/packages/aor-graphql-client/README.md
+++ b/packages/aor-graphql-client/README.md
@@ -90,7 +90,7 @@ You can specify the client options by calling `buildApolloClient` like this:
 import { createNetworkInterface } from 'react-apollo';
 
 buildApolloClient({
-    client: {
+    clientOptions: {
         networkInterface: createNetworkInterface({
             uri: 'http://api.myproduct.com/graphql',
         }),

--- a/packages/aor-graphql-client/src/index.js
+++ b/packages/aor-graphql-client/src/index.js
@@ -34,7 +34,8 @@ const getOptions = (options, aorFetchType, resource) => {
 
 export default async options => {
     const {
-        client: clientOptions,
+        client: clientObject,
+        clientOptions,
         introspection,
         resolveIntrospection,
         buildQuery: buildQueryFactory,
@@ -42,8 +43,7 @@ export default async options => {
         ...otherOptions
     } = merge({}, defaultOptions, options);
 
-    const client =
-        clientOptions && clientOptions instanceof ApolloClient ? clientOptions : buildApolloClient(clientOptions);
+    const client = clientObject && buildApolloClient(clientOptions);
 
     let introspectionResults;
     if (introspection) {


### PR DESCRIPTION
Trying to use `apollo-client` 2 .
Easiest way is pass apollo-client v2 object directly. But this check skips client and builds v1 client.

So, If this v1 client instanceOf check is removed we can use v2 client like this.

```
import buildApolloClient from 'aor-graphql-client-graphcool'
import ApolloClient from 'apollo-client';
import { HttpLink } from 'apollo-link-http';
import { ApolloLink, concat } from 'apollo-link';

  const client = new ApolloClient({
    link: new HttpLink({ uri: 'http://localhost:3000' }),
    cache: new InMemoryCache().restore(window.__APOLLO_STATE__),
  });

  buildApolloClient({
    client: apolloClient,
  })
```