### PR TITLE
Add dep required for yarn start

### DIFF
--- a/packages/admin-on-rest-graphql-demo/package.json
+++ b/packages/admin-on-rest-graphql-demo/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "admin-on-rest": "^1.3.2",
+    "aor-graphql-client": "^0.0.1",
     "aor-graphql-client-graphcool": "^0.0.1",
     "aor-language-french": "~1.8.0",
     "aor-rich-text-input": "~1.0.0",

--- a/packages/admin-on-rest-graphql-demo/yarn.lock
+++ b/packages/admin-on-rest-graphql-demo/yarn.lock
@@ -136,9 +136,45 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
+aor-graphql-client-graphcool@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/aor-graphql-client-graphcool/-/aor-graphql-client-graphcool-0.0.1.tgz#972847f6da22ad6e493f2d37f6b91dd4bc1c3821"
+  dependencies:
+    babel-plugin-transform-runtime "~6.23.0"
+    graphql "~0.11.7"
+    graphql-tag "~2.4.2"
+    lodash.merge "~4.6.0"
+    pluralize "~7.0.0"
+
+aor-graphql-client@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/aor-graphql-client/-/aor-graphql-client-0.0.1.tgz#2ed23a37aec65793cc2f1a55cb72c8019c099f5e"
+  dependencies:
+    aor-realtime "^0.0.1"
+    apollo-client "^1.9.3"
+    babel-plugin-transform-runtime "~6.23.0"
+    graphql "^0.11.7"
+    graphql-tag "^2.4.2"
+    lodash.get "~4.4.2"
+    lodash.merge "~4.6.0"
+    pluralize "~7.0.0"
+
 aor-language-french@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aor-language-french/-/aor-language-french-1.8.0.tgz#1012ec7131ff963ba13386a76a14707c9c096854"
+
+aor-realtime@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/aor-realtime/-/aor-realtime-0.0.1.tgz#22b137d478946a2dcadbc10c99694bbe9ddd93d4"
+  dependencies:
+    babel-plugin-transform-runtime "~6.23.0"
+    lodash.merge "~4.6.0"
+    lodash.omit "~4.5.0"
+    lodash.pick "~4.4.0"
+    lodash.pickby "~4.6.0"
+    react-router "~4.1.1"
+    react-router-redux "~5.0.0-alpha.5"
+    redux-saga "~0.14.6"
 
 aor-rich-text-input@~1.0.0:
   version "1.0.1"
@@ -149,7 +185,7 @@ aor-rich-text-input@~1.0.0:
     quill "~1.1.9"
     react "~15.4.0"
 
-apollo-client@~1.9.3:
+apollo-client@^1.9.3, apollo-client@~1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-1.9.3.tgz#37000b3c801f4571b7b089739e696a158896aeab"
   dependencies:
@@ -845,6 +881,12 @@ babel-plugin-transform-regenerator@6.22.0, babel-plugin-transform-regenerator@^6
 babel-plugin-transform-runtime@6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.22.0.tgz#10968d760bbf6517243081eec778e10fa828551c"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-runtime@~6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -2684,7 +2726,7 @@ graphql@^0.10.3:
   dependencies:
     iterall "^1.1.0"
 
-graphql@^0.11.3, graphql@~0.11.7:
+graphql@^0.11.3, graphql@^0.11.7, graphql@~0.11.7:
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:
@@ -3732,6 +3774,18 @@ lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.merge@~4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+
+lodash.omit@~4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
+lodash.pick@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
 lodash.pickby@^4.6.0, lodash.pickby@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
@@ -4671,6 +4725,14 @@ prop-types@^15.5.9, prop-types@~15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -4873,6 +4935,14 @@ react-router-dom@~4.2.2:
     react-router "^4.2.0"
     warning "^3.0.0"
 
+react-router-redux@~5.0.0-alpha.5:
+  version "5.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"
+  dependencies:
+    history "^4.7.2"
+    prop-types "^15.6.0"
+    react-router "^4.2.0"
+
 react-router-redux@~5.0.0-alpha.6:
   version "5.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.6.tgz#7418663c2ecd3c51be856fcf28f3d1deecc1a576"
@@ -4902,6 +4972,18 @@ react-router@^4.2.0:
     invariant "^2.2.2"
     loose-envify "^1.3.1"
     path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
+
+react-router@~4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.1.2.tgz#7ae027341abc42eb08ad9f7a8cac08d0563672ce"
+  dependencies:
+    history "^4.6.0"
+    hoist-non-react-statics "^1.2.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.5.3"
     prop-types "^15.5.4"
     warning "^3.0.0"
 
@@ -5102,6 +5184,10 @@ redux-form@~7.0.3, redux-form@~7.0.4:
     lodash "^4.17.3"
     lodash-es "^4.17.3"
     prop-types "^15.5.9"
+
+redux-saga@~0.14.6:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.14.8.tgz#ad01afabe02ec41a17df54e2e09aa236b30a7732"
 
 redux-saga@~0.15.0, redux-saga@~0.15.6:
   version "0.15.6"


### PR DESCRIPTION
I needed this otherwise `yarn start` was throwing errors both in the console and when opening http://localhost:3000.

Proper fix should probably be to put the dependency in `aor-graphql-client-graphcool` but I don't really know how to link dependencies within my local repo to test it out...

```
Failed to compile.

Error in ./~/aor-graphql-client-graphcool/lib/index.js
Module not found: 'aor-graphql-client' in /Users/sdubois/Repos/aor-graphql/packages/admin-on-rest-graphql-demo/node_modules/aor-graphql-client-graphcool/lib

 @ ./~/aor-graphql-client-graphcool/lib/index.js 11:24-53

Error in ./~/aor-graphql-client-graphcool/lib/buildVariables.js
Module not found: 'aor-graphql-client/lib/constants' in /Users/sdubois/Repos/aor-graphql/packages/admin-on-rest-graphql-demo/node_modules/aor-graphql-client-graphcool/lib

 @ ./~/aor-graphql-client-graphcool/lib/buildVariables.js 19:17-60

Error in ./~/aor-graphql-client-graphcool/lib/buildGqlQuery.js
Module not found: 'aor-graphql-client/lib/constants' in /Users/sdubois/Repos/aor-graphql/packages/admin-on-rest-graphql-demo/node_modules/aor-graphql-client-graphcool/lib

 @ ./~/aor-graphql-client-graphcool/lib/buildGqlQuery.js 16:17-60

Error in ./~/aor-graphql-client-graphcool/lib/getResponseParser.js
Module not found: 'aor-graphql-client/lib/constants' in /Users/sdubois/Repos/aor-graphql/packages/admin-on-rest-graphql-demo/node_modules/aor-graphql-client-graphcool/lib

 @ ./~/aor-graphql-client-graphcool/lib/getResponseParser.js 21:17-60
```